### PR TITLE
The proper fonts are now being rendered in the Celo Reserves site

### DIFF
--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -8,7 +8,7 @@ const garamond = "EB Garamond, eb-garamond, Garamond, serif"
 const globalStyles = css`
   x * {
     box-sizing: border-box;
-    font-family: "${garamond}";
+    font-family: ${garamond};
   }
 
   h1,
@@ -19,7 +19,7 @@ const globalStyles = css`
   a {
     margin-top: 0;
     color: ${colors.dark};
-    font-family: "${garamond}";
+    font-family: ${garamond};
     font-display: "swap";
   }
 
@@ -81,7 +81,7 @@ const globalStyles = css`
   body {
     margin: 0;
     padding: 0;
-    font-family: "${garamond}";
+    font-family: ${garamond};
     font-display: "swap";
     display: flex;
     justify-content: "center";


### PR DESCRIPTION
***Description***
Before the Celo reserves site was rendering the wrong font.
<img width="411" alt="Screen Shot 2021-06-14 at 11 57 13 AM" src="https://user-images.githubusercontent.com/55670305/121922435-f7282300-cd07-11eb-898f-1856b3575430.png">

But with a little debugging, I was able to render the right font for the site.
<img width="409" alt="Screen Shot 2021-06-14 at 11 51 58 AM" src="https://user-images.githubusercontent.com/55670305/121922500-08712f80-cd08-11eb-96ae-8422348b7056.png">
