### PR TITLE
Update Cached values slightly less

### DIFF
--- a/src/service/holdings.ts
+++ b/src/service/holdings.ts
@@ -37,8 +37,6 @@ async function getSumBalance(token: Tokens, balanceFetcher: (address: string) =>
   return balances.reduce(sumMerge)
 }
 
-refresh("btc-balance", 5 * MINUTE, fetchBTCBalance)
-
 export async function btcBalance() {
   return getOrSave<Duel>("btc-balance", fetchBTCBalance, 10 * MINUTE)
 }
@@ -48,7 +46,6 @@ async function fetchETHBalance() {
     return duel(etherscan.getETHBalance(address), ethplorer.getETHBalance(address))
   })
 }
-refresh("eth-balance", 5 * MINUTE, fetchETHBalance)
 
 export async function ethBalance() {
   return getOrSave<Duel>("eth-balance", fetchETHBalance, 10 * MINUTE)
@@ -59,7 +56,6 @@ function fetchDaiBalance() {
     return duel(etherscan.getDaiBalance(address), ethplorer.getDaiBalance(address))
   })
 }
-refresh("dai-balance", 5 * MINUTE, fetchDaiBalance)
 
 export async function daiBalance() {
   return getOrSave<Duel>("dai-balance", fetchDaiBalance, 10 * MINUTE)
@@ -69,8 +65,6 @@ export async function celoCustodiedBalance() {
   return getOrSave<ProviderSource>("celo-custody-balance", getInCustodyBalance, 5 * MINUTE)
 }
 
-refresh("celo-custody-balance", 5 * MINUTE, getInCustodyBalance)
-
 export async function cMC02Balance() {
   return getOrSave<ProviderSource>("cmc02-balance", getcMC02Balance, 10 * MINUTE)
 }
@@ -79,13 +73,9 @@ export async function celoFrozenBalance() {
   return getOrSave<ProviderSource>("celo-frozen-balance", getFrozenBalance, 5 * MINUTE)
 }
 
-refresh("celo-frozen-balance", 5 * MINUTE, getFrozenBalance)
-
 export async function celoUnfrozenBalance() {
   return getOrSave<ProviderSource>("celo-unfrozen-balance", getUnFrozenBalance, 2 * MINUTE)
 }
-
-refresh("celo-unfrozen-balance", 5 * MINUTE, getUnFrozenBalance)
 
 export interface HoldingsApi {
   celo: {

--- a/src/service/rates.ts
+++ b/src/service/rates.ts
@@ -3,7 +3,7 @@ import { ISO427SYMBOLS } from "src/interfaces/ISO427SYMBOLS"
 import currencyInUSD from "src/providers/ExchangeRateAPI"
 import { getCeloPrice } from "src/providers/Celo"
 import { getEthPrice } from "src/providers/Etherscan"
-import { refresh, getOrSave, Cachable } from "src/service/cache"
+import { getOrSave, Cachable } from "src/service/cache"
 import { HOUR, MINUTE } from "src/utils/TIME"
 import duel, { Duel } from "./duel"
 import { getCMC02Price } from "src/providers/UbeSwapGraph"
@@ -24,20 +24,17 @@ async function fetchBTCPrice() {
   return price
 }
 
-refresh("btc-price", 2 * MINUTE, fetchBTCPrice)
-
 export async function btcPrice() {
-  return getOrSave<Duel>("btc-price", fetchBTCPrice, 2 * MINUTE)
+  return getOrSave<Duel>("btc-price", fetchBTCPrice, 4 * MINUTE)
 }
 
 async function fetchETHPrice() {
   const price = await duel(coinbase.getETHInUSD(), getEthPrice())
   return price
 }
-refresh("eth-price", 10 * MINUTE, fetchETHPrice)
 
 export async function ethPrice() {
-  return getOrSave<Duel>("eth-price", fetchETHPrice, 2 * MINUTE)
+  return getOrSave<Duel>("eth-price", fetchETHPrice, 4 * MINUTE)
 }
 
 export async function fiatPrices() {
@@ -48,7 +45,6 @@ async function fetchCELOPrice() {
   const price = await duel(getCeloPrice(), coinbase.getCELOPrice())
   return price
 }
-refresh("celo-price", 2 * MINUTE, fetchCELOPrice)
 
 export async function celoPrice() {
   return getOrSave<Duel>("celo-price", fetchCELOPrice, 1 * MINUTE)


### PR DESCRIPTION
Got a message that the rate limit has been reached on coin market cap. We had adjusted the frequency of calls before and probably went more than we needed. 

This PR changes
invalidate cache less often.

`refresh` not actually needed so remove those calls. this was basically a timer that would go over ever x seconds, but since requests themselves can trigger cache invalidations its not needed